### PR TITLE
Move JSDoc updateData description to correct place

### DIFF
--- a/src/api-tdx.js
+++ b/src/api-tdx.js
@@ -919,8 +919,8 @@ class TDXApi {
    * @param  {object|array} data - The data to update. Must conform to the schema defined by the resource metadata.
    * Supports updating individual or multiple documents.
    * @param  {bool} [upsert=false] - Indicates the data should be created if no document is found matching the
-   * @param  {bool} [doNotThrow=false] - set to override default error handling. See {@link TDXApi}.
    * primary key.
+   * @param  {bool} [doNotThrow=false] - set to override default error handling. See {@link TDXApi}.
    * @param  {object} [opts] - reserved for system use.
    * @return {CommandResult} - Use the result property to check for errors.
    * @example <caption>update an existing document</caption>


### PR DESCRIPTION
Part of `updateData`'s `upsert` parameter description is under `doNotThrow`.
Looks like this was accidentally added in b30438ef058c7ea4fd0da2f81256514ea618df23.