### PR TITLE
Add JSDoc documentation on getResourceAccess func

### DIFF
--- a/src/api-tdx.js
+++ b/src/api-tdx.js
@@ -1609,7 +1609,12 @@ class TDXApi {
 
   /**
    * Gets all access the authenticated account has to the given resource id.
+   *
    * @param  {string} resourceId - The id of the resource whose access is to be retrieved.
+   * @param  {object} [filter] - A mongodb filter definition.
+   * @param  {object} [projection] - A mongodb projection definition, can be used to restrict which properties are
+   * returned thereby limiting the payload.
+   * @param  {object} [options] - A mongodb options definition, can be used for limit, skip, sorting etc.
    * @return {ResourceAccess[]} - Array of ResourceAccess objects.
    * @example
    * api.getResourceAccess(myResourceId)


### PR DESCRIPTION
Previously, the `filter`/`projection`/`options` args were missing from the docs.

I wasn't 100% sure whether to make this PR here or in the new mono-repo, but I guess since the API Docs are hosted on this repo (at https://nqminds.github.io/nqm-api-tdx/TDXApi.html#getResourceAccess) they should go here? 