### PR TITLE
Update the `fileUpload()` documentation

### DIFF
--- a/src/api-tdx.js
+++ b/src/api-tdx.js
@@ -493,6 +493,13 @@ class TDXApi {
   /**
    * Upload a file to a TDX resource.
    *
+   * Upload progress can be viewed by running:
+   *
+   * ```js
+   * const {contants} = require("@nqminds/nqm-core-tdx-utils");
+   * const {data: uploadStatus} = await api.getData(constants.uploadStatusFilterResourceId, {resourceId});
+   * ```
+   *
    * @param  {string} resourceId - The id of the destination resource.
    * @param  {File} file - The Web API [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File) to upload.
    * - On browser, this is usually obtained from an `<input type="file">` element.
@@ -510,6 +517,21 @@ class TDXApi {
    * @throws {Error} Rejects with a TDXApiError if the upload failed.
    * @returns {Promise<{ok: true}> | Promise<Response>} Resolves with `{ok: true}` if the upload was successful.
    * - _Deprecated_: If `stream=true`, returns the {@link Response} object.
+   * @example <caption>Upload a file to a resource</caption>
+   * import TDXApi from "@nqminds/nqm-api-tdx";
+   * import {constants} from "@nqminds/nqm-core-utils";
+   * const file = new File(["Hello World\n"], "hello.txt", {type: "text/plain"});
+   * const api = new TDXApi(...);
+   * const {resourceId} = await api.addResource({name: "hello.txt", fileType: constants.rawFileType});
+   * await api.uploadFile(resourceId, file);
+   * @example <caption>Print progress when uploading a file</caption>
+   * // [...] It's probably more efficient to use @nqminds/nqm-tdx-connections to subscribe to changes
+   * const progress = setInterval(  // get and log upload progress from TDX
+   *   async() => console.log(await api.getData(constants.uploadStatusFilterResourceId, {resourceId})),
+   *   10000,
+   * );
+   * await api.uploadFile(resourceId, file);
+   * clearInterval(progress);
    */
   fileUpload(resourceId, file, stream, compressed = false, base64Encoded = false) {
     const request = buildFileUploadRequest.call(this, resourceId, compressed, base64Encoded, file);

--- a/src/api-tdx.js
+++ b/src/api-tdx.js
@@ -491,14 +491,25 @@ class TDXApi {
   }
 
   /**
-   * Upload a file to a resource.
+   * Upload a file to a TDX resource.
+   *
    * @param  {string} resourceId - The id of the destination resource.
-   * @param  {object} file - The file to upload, obtained from an `<input type="file">` element.
-   * @param  {boolean} [stream=false] - Flag indicating whether the call should return a stream allowing
-   * callees to monitor progress.
+   * @param  {File} file - The Web API [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File) to upload.
+   * - On browser, this is usually obtained from an `<input type="file">` element.
+   * - On Node.JS, due to limitations of `node-fetch` v2, the `file.stream()` method must return
+   * a [Node.JS `Readable` steam](https://nodejs.org/api/stream.html#stream_class_stream_readable).
+   * [Web API `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)
+   * (such as from the "fetch-blob" library) are not supported.
+   * @param  {boolean} [stream=false] - _Deprecated_: Flag indicating whether the call should
+   * directly return the {@link Response} object.
+   * Since @nqminds/nqm-api-tdx v0.9.0, this parameter is deprecated, as the `fetch` request only
+   * returns a plain JSON object on success/failure.
    * @param  {boolean} [compressed=false] - Flag indicating the file should be decompressed after upload. ZIP format
    * only.
-   * @param  {boolean} [base64Encoded=false] = Flag indicating the file should be decoded from base64 after upload.
+   * @param  {boolean} [base64Encoded=false] - Flag indicating the file should be decoded from base64 after upload.
+   * @throws {Error} Rejects with a TDXApiError if the upload failed.
+   * @returns {Promise<{ok: true}> | Promise<Response>} Resolves with `{ok: true}` if the upload was successful.
+   * - _Deprecated_: If `stream=true`, returns the {@link Response} object.
    */
   fileUpload(resourceId, file, stream, compressed = false, base64Encoded = false) {
     const request = buildFileUploadRequest.call(this, resourceId, compressed, base64Encoded, file);


### PR DESCRIPTION
The `fileUpload()` function has some _interesting_ behaviour.

Firstly, due to `node-fetch` v2, the `file` field's `.stream()` method **MUST** return a Node.JS Readable Stream, not just a Web API ReadableStream.

E.g. it has to be an:
  -  [`import {Readable}  from "node:stream"`](https://nodejs.org/api/stream.html#class-streamreadable)
  - (**not** [`import {ReadableStream}  from "node:stream/web"`](https://nodejs.org/api/webstreams.html#class-readablestream))

This is a bit counter-intuitive, since `node-fetch` v3 and a few other libraries have a File API that only returns `ReadableStream`s, which aren't compatible with `node-fetch` v2.

Secondly, the `stream` param doesn't really have any purpose nowadays. Viewing upload progress nowadays seems to be done by looking at the dataset, `require("@nqminds/nqm-core-utils").constants.uploadStatusFilterResourceId`, so instead I added that to the docs.